### PR TITLE
Bug in Result.Decode() leads to ignoring data

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -138,6 +138,8 @@ func (res Result) decode(v reflect.Value, fullName string) error {
     var name string
     var val interface{}
     var ok bool
+    var err error
+    var ret error
 
     num := v.Type().NumField()
 
@@ -147,15 +149,19 @@ func (res Result) decode(v reflect.Value, fullName string) error {
         val, ok = res[name]
 
         if !ok {
-            log.Printf("cannot find field '%v%v' in result.", fullName, name)
+            err = fmt.Errorf("cannot find field '%v%v' in result.", fullName, name)
+        } else {
+            err = decodeField(val, field, fmt.Sprintf("%v%v", fullName, name))
         }
-
-        if err := decodeField(val, field, fmt.Sprintf("%v%v", fullName, name)); err != nil {
+        if err != nil {
+            // Log each error
             log.Println(err)
+            // Return the lastest error
+            ret = err
         }
     }
 
-    return nil
+    return ret
 }
 
 func decodeField(val interface{}, field reflect.Value, fullName string) error {


### PR DESCRIPTION
Hello,

Thank you for this project, I am playing with the Facebook graph API through it.
I had an annoyance when trying to convert my https://graph.facebook.com/me page directly into a golang structure using _Decode()_ (from _misc.go_) ; some fields (retrieved from the graph API call) were missing.

After investigating _misc.go_ (and _decode()_), the fix was written ; instead of returning from the function (and especially from the _for loop_) on failures, just log them.

Amodio
