### PR TITLE
make sure Result.Get("a.b.c") actually works

### DIFF
--- a/facebook_test.go
+++ b/facebook_test.go
@@ -456,6 +456,18 @@ func TestResultDecode(t *testing.T) {
         t.Errorf("invalid array value. expected 56, actual %v", anInt)
         return
     }
+
+    err = result.DecodeField("nested_struct.int", &anInt)
+
+    if err != nil {
+        t.Errorf("cannot decode nested struct item. [e:%v]", err)
+        return
+    }
+
+    if anInt != 123 {
+        t.Errorf("invalid array value. expected 123, actual %v", anInt)
+        return
+    }
 }
 
 func TestParamsEncode(t *testing.T) {

--- a/misc.go
+++ b/misc.go
@@ -72,13 +72,13 @@ func (res Result) get(fields []string) interface{} {
         }
     }
 
-    res, ok = v.(Result)
+    res, ok = v.(map[string]interface{})
 
     if !ok {
         return nil
     }
 
-    return res.get(fields[1:])
+    return Result(res).get(fields[1:])
 }
 
 // Decodes full result to a struct.


### PR DESCRIPTION
Result.DecodeField("a.b.c") didn't actually work because a `map[string]interface{}` cannot be directly type asserted as `Result`.

Also added a test case to test for this.
