### PR TITLE
Add Get(), Post(), Put() and Delete() helper methods to the Session type

### DIFF
--- a/session.go
+++ b/session.go
@@ -33,6 +33,26 @@ func (session *Session) Api(path string, method Method, params Params) (Result, 
     return nil, err
 }
 
+// Get is a short hand of Api(path, GET, params).
+func (session *Session) Get(path string, params Params) (Result, error) {
+    return session.Api(path, GET, params)
+}
+
+// Post is a short hand of Api(path, POST, params).
+func (session *Session) Post(path string, params Params) (Result, error) {
+    return session.Api(path, POST, params)
+}
+
+// Delete is a short hand of Api(path, DELETE, params).
+func (session *Session) Delete(path string, params Params) (Result, error) {
+    return session.Api(path, DELETE, params)
+}
+
+// Put is a short hand of Api(path, PUT, params).
+func (session *Session) Put(path string, params Params) (Result, error) {
+    return session.Api(path, PUT, params)
+}
+
 // Makes a batch call. Each params represent a single facebook graph api call.
 //
 // BatchApi supports most kinds of batch calls defines in facebook batch api document,


### PR DESCRIPTION
A quick fix to make the Session type consistent with the doc and with the package-level functions. At the moment, this code in Scenario 3 in the doc doesn't compile as the Session type is missing those helper methods:

```
res, _ := session.Get("/me/feed", nil)
```

This pull requests fixes that. And those helper methods are quite handy is any case.
