### PR TITLE
Add support for custom http.Client per Session

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,7 +13,6 @@ import (
     "crypto/sha256"
     "encoding/json"
     "fmt"
-    "net/http"
     "net/url"
     "strconv"
     "strings"
@@ -242,16 +241,6 @@ func (app *App) Session(accessToken string) *Session {
     return &Session{
         accessToken: accessToken,
         app:         app,
-        httpClient:  http.DefaultClient,
-    }
-}
-
-// Creates a session based on current App setting, using a custom http client
-func (app *App) SessionHTTPClient(accessToken string, httpClient *http.Client) *Session {
-    return &Session{
-        accessToken: accessToken,
-        app:         app,
-        httpClient:  httpClient,
     }
 }
 
@@ -277,7 +266,6 @@ func (app *App) SessionFromSignedRequest(signedRequest string) (session *Session
             accessToken: token,
             app:         app,
             id:          id,
-            httpClient:  http.DefaultClient,
         }
         return
     }
@@ -301,7 +289,6 @@ func (app *App) SessionFromSignedRequest(signedRequest string) (session *Session
         accessToken: token,
         app:         app,
         id:          id,
-        httpClient:  http.DefaultClient,
     }
     return
 }

--- a/session.go
+++ b/session.go
@@ -13,6 +13,7 @@ import (
     "encoding/json"
     "fmt"
     "io"
+    "net/http"
     "strings"
 )
 
@@ -252,7 +253,12 @@ func (session *Session) makeRequest(url string, params Params) ([]byte, error) {
         return nil, fmt.Errorf("cannot encode params. %v", err)
     }
 
-    response, err := session.httpClient.Post(url, mime, buf)
+    var response *http.Response
+    if session.HttpClient == nil {
+        response, err = http.DefaultClient.Post(url, mime, buf)
+    } else {
+        response, err = session.HttpClient.Post(url, mime, buf)
+    }
 
     if err != nil {
         return nil, fmt.Errorf("cannot reach facebook server. %v", err)

--- a/type.go
+++ b/type.go
@@ -27,7 +27,7 @@ type App struct {
 // Holds a facebook session with an access token.
 // Session should be created by App.Session or App.SessionFromSignedRequest.
 type Session struct {
-    httpClient  *http.Client
+    HttpClient  *http.Client
     accessToken string // facebook access token. can be empty.
     app         *App
     id          string


### PR DESCRIPTION
A short addition allowing a session to use a particular http.Client.
