### PR TITLE
Add support for access tokens without expire date

### DIFF
--- a/app.go
+++ b/app.go
@@ -170,8 +170,10 @@ func (app *App) ExchangeToken(accessToken string) (token string, expires int, er
 
     // successfully get a new token.
     if token != "" {
-        expiresStr := values.Get("expires")
-        expires, err = strconv.Atoi(expiresStr)
+        if _, ok := values["expires"]; ok {
+            expiresStr := values.Get("expires")
+            expires, err = strconv.Atoi(expiresStr)
+        }
         return
     }
 


### PR DESCRIPTION
I came across an error when trying to get a permanent access token from a temporary. This should fix errors that look like this:

```
strconv.ParseInt: parsing "": invalid syntax
```
