### PR TITLE
Add way to access fields that is not confused by a '.' in the key names

### DIFF
--- a/result.go
+++ b/result.go
@@ -48,6 +48,23 @@ func (res Result) Get(field string) interface{} {
 	return res.get(f)
 }
 
+// Gets a field.
+//
+// Args are treated as what keys to access in the result
+// It means, if args are "a","b","c", gets field value res["a"]["b"]["c"].
+//
+// To access array items, use index value as a string.
+// For instance, args of "a", "0", "c" means to read res["a"][0]["c"].
+//
+// Returns nil if field doesn't exist.
+func (res Result) GetField(fields ...string) interface{} {
+	if len(fields) == 0 {
+		return res
+	}
+
+	return res.get(fields)
+}
+
 func (res Result) get(fields []string) interface{} {
 	v, ok := res[fields[0]]
 


### PR DESCRIPTION
I ran into a problem today where `Result.Get` wouldn't work, because the key name was a file name, and had a `'.'` in the key name, like so: `{"images":{"image.jpg":{"hash":1234}}}`

When `Result.Get` is called with `"images.image.jpg.hash"`, it causes the call to `strings.Split` to count too many fields, and returns `nil` and not `1234`

This alternative implementation will not have this problem, since it will never need to split, each key is treated as a separate string.

If you like, I can replace the current implementation of `Result.Get` with this one, but it would be a breaking change to all programs currently using the API. This is why I've chosen to submit this as a different function.
