### PR TITLE
fix infinite loop in paging by clearing Next/Previous fields from previous query

### DIFF
--- a/paging_result.go
+++ b/paging_result.go
@@ -115,6 +115,10 @@ func (pr *PagingResult) navigate(url *string) (noMore bool, err error) {
 		return
 	}
 
+	if pr.paging.Paging != nil {
+		pr.paging.Paging.Next = ""
+		pr.paging.Paging.Previous = ""
+	}
 	paging := &pr.paging
 	err = res.Decode(paging)
 


### PR DESCRIPTION
Since pr.paging.Paging is being reused, before decoding a new response we must clear out Next/Previous from previous response. Otherwise, missing values in the response will leave the data from previous response, resulting in e.g. infinite loop when paging forward.
