### PR TITLE
Updating exchange token to user new 'expires' value instead of 'expires_in'

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,6 +13,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -165,7 +166,11 @@ func (app *App) ExchangeToken(accessToken string) (token string, expires int, er
 		return
 	}
 
-	err = res.DecodeField("expires_in", &expires)
+	var expiresString string
+	err = res.DecodeField("expires", &expiresString)
+	if err == nil {
+		expires, err = strconv.Atoi(expiresString)
+	}
 	return
 }
 


### PR DESCRIPTION
I can't seem to find any reason as to why the response return 'expires' as the documentation talks about 'expires_in', but this was required to get the long lived tokens working.
see: https://developers.facebook.com/docs/facebook-login/access-tokens#apptokens