### PR TITLE
Guess content type for binary params by filename extension

### DIFF
--- a/const.go
+++ b/const.go
@@ -26,6 +26,7 @@ const (
 	ERROR_CODE_UNKNOWN = -1 // unknown facebook graph api error code.
 
 	_MIME_FORM_URLENCODED = "application/x-www-form-urlencoded"
+	_MIME_FORM_DATA = "multipart/form-data"
 )
 
 // Graph API debug mode values.

--- a/facebook_test.go
+++ b/facebook_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"strings"
 )
 
 const (
@@ -888,6 +889,27 @@ func TestParamsEncode(t *testing.T) {
 
 	mime, err := params.Encode(buf)
 	t.Logf("complex encode result is '%v'. [e:%v] [mime:%v]", buf.String(), err, mime)
+}
+
+func TestBinaryParamsEncode(t *testing.T) {
+
+	buf := &bytes.Buffer{}
+	params := Params{}
+	params["attachment"] = FileAlias("image.jpg", "LICENSE")
+
+	contentTypeImage := "Content-Type: image/jpeg"
+	if mime, err := params.Encode(buf); err != nil || !strings.Contains(mime, _MIME_FORM_DATA) || !strings.Contains(buf.String(), contentTypeImage) {
+		t.Fatalf("wrong binary params encode result. expected content type is '%v'. actual is '%v'. [e:%v] [mime:%v]", contentTypeImage, buf.String(), err, mime)
+	}
+
+	// Fallback for unknown content types
+	// should be application/octet-stream
+	buf.Reset()
+	params = Params{"attachment": FileAlias("image.unknown", "LICENSE")}
+	contentTypeOctet := "Content-Type: application/octet-stream"
+	if mime, err := params.Encode(buf); err != nil || !strings.Contains(mime, _MIME_FORM_DATA) || !strings.Contains(buf.String(), contentTypeOctet) {
+		t.Fatalf("wrong binary params encode result. expected content type is '%v'. actual is '%v'. [e:%v] [mime:%v]", contentTypeOctet, buf.String(), err, mime)
+	}
 }
 
 func TestStructFieldTag(t *testing.T) {


### PR DESCRIPTION
I use this library to send messages to Facebook messenger and it turned out that Facebook requires proper content type in multipart form field data for images. Otherwise it always returns error.