### PR TITLE
Handle string errors in Decode()

### DIFF
--- a/result.go
+++ b/result.go
@@ -10,6 +10,7 @@ package facebook
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -216,7 +217,17 @@ func (res Result) Decode(v interface{}) (err error) {
 				panic(r)
 			}
 
-			err = r.(error)
+			if errStr, ok := r.(string); ok {
+				err = errors.New(errStr)
+				return
+			}
+
+			if errErr, ok := r.(error); ok {
+				err = errErr
+				return
+			}
+
+			panic(r)
 		}
 	}()
 


### PR DESCRIPTION
It's possible that Decode() panics with a plain `string`. The `string` is
type asserted to `error` which fails due to `string` not implementing
the `error` interface.

Example panic with string:

    reflect: reflect.Value.Set using value obtained using unexported field