### PR TITLE
Fix regexpIsVideoPost

### DIFF
--- a/const.go
+++ b/const.go
@@ -61,7 +61,7 @@ var (
 	}
 
 	// checks whether it's a video post.
-	regexpIsVideoPost = regexp.MustCompile("\\/videos$")
+	regexpIsVideoPost = regexp.MustCompile(`\/videos$`)
 
 	// default facebook session.
 	defaultSession = &Session{}

--- a/const.go
+++ b/const.go
@@ -61,7 +61,7 @@ var (
 	}
 
 	// checks whether it's a video post.
-	regexpIsVideoPost = regexp.MustCompile("/videos")
+	regexpIsVideoPost = regexp.MustCompile("\\/videos$")
 
 	// default facebook session.
 	defaultSession = &Session{}

--- a/const.go
+++ b/const.go
@@ -61,7 +61,7 @@ var (
 	}
 
 	// checks whether it's a video post.
-	regexpIsVideoPost = regexp.MustCompile(`/^(\/)(.+)(\/)(videos)$/`)
+	regexpIsVideoPost = regexp.MustCompile("/videos")
 
 	// default facebook session.
 	defaultSession = &Session{}


### PR DESCRIPTION
The previous regular expression statement was difficult to read and would not catch "me/videos" links.
Now it is more readable and catches any instance of "/videos".
