### PR TITLE
Compatible with json tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,23 +179,24 @@ type Data struct {
 }
 ```
 
-Decoding behavior can be changed per field through field tag -- just like what `encoding/json` does.
+The decoding of each struct field can be customized by the format string stored under the "facebook" key or the "json" key in the struct field's tag. The "facebook" key is recommended as it's specifically designed for this package.
 
 Following is a sample shows all possible field tags.
 
 ```go
 // define a facebook feed object.
 type FacebookFeed struct {
-    Id          string `facebook:",required"`             // this field must exist in response.
-                                                          // mind the "," before "required".
+    Id          string            `facebook:",required"`             // this field must exist in response.
+                                                                     // mind the "," before "required".
     Story       string
-    FeedFrom    *FacebookFeedFrom `facebook:"from"`       // use customized field name "from".
-    CreatedTime string `facebook:"created_time,required"` // both customized field name and "required" flag.
-    Omitted     string `facebook:"-"`                     // this field is omitted when decoding.
+    FeedFrom    *FacebookFeedFrom `facebook:"from"`                  // use customized field name "from".
+    CreatedTime string            `facebook:"created_time,required"` // both customized field name and "required" flag.
+    Omitted     string            `facebook:"-"`                     // this field is omitted when decoding.
 }
 
 type FacebookFeedFrom struct {
-    Name, Id string
+    Name string `json:"name"`                   // the "json" key also works as expected.
+    Id string   `facebook:"id" json:"shadowed"` // if both "facebook" and "json" key are set, the "facebook" key is used.
 }
 
 // create a feed object direct from graph api result.

--- a/batch_result.go
+++ b/batch_result.go
@@ -13,14 +13,14 @@ import (
 )
 
 type batchResultHeader struct {
-	Name  string `facebook=",required"`
-	Value string `facebook=",required"`
+	Name  string `facebook:",required"`
+	Value string `facebook:",required"`
 }
 
 type batchResultData struct {
-	Code    int                 `facebook=",required"`
-	Headers []batchResultHeader `facebook=",required"`
-	Body    string              `facebook=",required"`
+	Code    int                 `facebook:",required"`
+	Headers []batchResultHeader `facebook:",required"`
+	Body    string              `facebook:",required"`
 }
 
 func newBatchResult(res Result) (*BatchResult, error) {

--- a/result_test.go
+++ b/result_test.go
@@ -987,3 +987,57 @@ func TestResultDecodeUnmarshaler(t *testing.T) {
 		t.Fatalf("input should fail due to Unmarshaler.")
 	}
 }
+
+type MixedTagStruct struct {
+	Foo        int     `facebook:"bar" json:"player"`
+	FirstTest  string  `facebook:"" json:"first"`
+	SecondTest float64 `json:"second"`
+	ThirdTest  uint32  `json:"-"`
+	FourthTest int64   `facebook:",required" json:"fourth"`
+}
+
+func TestCompatibleWithJSONUnmarshal(t *testing.T) {
+	res := Result{
+		"foo":    1,
+		"bar":    2,
+		"player": 3,
+
+		"first_test": "first",
+		"first":      "test",
+
+		"second_test": 1.2,
+		"second":      3.4,
+
+		"third_test": 5,
+		"-":          6,
+
+		"fourth_test": 7,
+		"fourth":      8,
+	}
+	mts := &MixedTagStruct{}
+	err := res.Decode(mts)
+
+	if err != nil {
+		t.Fatalf("fail to decode result. [e:%v]", err)
+	}
+
+	if expected := 2; mts.Foo != expected {
+		t.Fatalf("mts.Foo is incorrect. [expected:%v] [actual:%v]", expected, mts.Foo)
+	}
+
+	if expected := "test"; mts.FirstTest != expected {
+		t.Fatalf("mts.FirstTest is incorrect. [expected:%v] [actual:%v]", expected, mts.FirstTest)
+	}
+
+	if expected := 3.4; mts.SecondTest != expected {
+		t.Fatalf("mts.SecondTest is incorrect. [expected:%v] [actual:%v]", expected, mts.SecondTest)
+	}
+
+	if expected := uint32(0); mts.ThirdTest != expected {
+		t.Fatalf("mts.ThirdTest is incorrect. [expected:%v] [actual:%v]", expected, mts.ThirdTest)
+	}
+
+	if expected := int64(7); mts.FourthTest != expected {
+		t.Fatalf("mts.FourthTest is incorrect. [expected:%v] [actual:%v]", expected, mts.FourthTest)
+	}
+}


### PR DESCRIPTION
If a struct field's tag contains a "json" key, this package can work similar to `json.Unmarshal`. If both the "facebook" key and the "json" key exist, the "facebook" key is used.