### PR TITLE
Add rate limit support

### DIFF
--- a/result.go
+++ b/result.go
@@ -82,6 +82,20 @@ type DebugInfo struct {
 	FacebookRev        string // the x-fb-rev HTTP header.
 }
 
+// UsageInfo is the app usage (rate limit) information returned by facebook when rate limits are possible.
+type UsageInfo struct {
+	App struct {
+		CallCount    int `json:"call_count"`
+		TotalTime    int `json:"total_time"`
+		TotalCPUTime int `json:"total_cputime"`
+	} `json:"app"`
+	Page struct {
+		CallCount    int `json:"call_count"`
+		TotalTime    int `json:"total_time"`
+		TotalCPUTime int `json:"total_cputime"`
+	} `json:"page"`
+}
+
 // DebugMessage is one debug message in "__debug__" of graph API response.
 type DebugMessage struct {
 	Type    string
@@ -431,6 +445,15 @@ func (res Result) DebugInfo() *DebugInfo {
 	}
 
 	return debugInfo
+}
+
+// UsageInfo returns app and page usage info (rate limits)
+func (res Result) UsageInfo() *UsageInfo {
+	if usageInfo, ok := res["__usage__"]; ok {
+		ui := usageInfo.(UsageInfo)
+		return &ui
+	}
+	return nil
 }
 
 func (res Result) decode(v reflect.Value, fullName string) error {

--- a/session.go
+++ b/session.go
@@ -143,6 +143,7 @@ func (session *Session) Request(request *http.Request) (res Result, err error) {
 
 	res, err = MakeResult(data)
 	session.addDebugInfo(res, response)
+	session.addUsageInfo(res, response)
 
 	if res != nil {
 		err = res.Err()
@@ -347,6 +348,7 @@ func (session *Session) graph(path string, method Method, params Params) (res Re
 	var response *http.Response
 	response, err = session.sendPostRequest(graphUrl, params, &res)
 	session.addDebugInfo(res, response)
+	session.addUsageInfo(res, response)
 
 	if res != nil {
 		err = res.Err()
@@ -558,6 +560,18 @@ func (session *Session) addDebugInfo(res Result, response *http.Response) Result
 	debugInfo[debugHeaderKey] = response.Header
 
 	res["__debug__"] = debugInfo
+	return res
+}
+
+func (session *Session) addUsageInfo(res Result, response *http.Response) Result {
+	var usageInfo UsageInfo
+	if response.Header.Get("X-App-Usage") != "" {
+		json.Unmarshal([]byte(response.Header.Get("X-App-Usage")), &usageInfo.App)
+	}
+	if response.Header.Get("X-Page-Usage") != "" {
+		json.Unmarshal([]byte(response.Header.Get("X-Page-Usage")), &usageInfo.Page)
+	}
+	res["__usage__"] = usageInfo
 	return res
 }
 


### PR DESCRIPTION
This adds a new function `UsageInfo` to `Result` which returns a struct containing the values found in the `X-App-Usage` and `X-Page-Usage` headers.