### PR TITLE
http Client update

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ res.DecodeField("data.0", &feed) // read latest feed
 
 ```go
 params1 := Params{
-    "method": fb.GET,
+    "method": http.MethodGet,
     "relative_url": "me",
 }
 params2 := Params{
-    "method": fb.GET,
+    "method": http.MethodGet,
     "relative_url": uint64(100002828925788),
 }
 results, err := fb.BatchApi(your_access_token, params1, params2)
@@ -269,7 +269,7 @@ See [Platform Versioning](https://developers.facebook.com/docs/apps/versions) to
 fb.Version = "v2.0"
 
 // starting with graph API v2.0; it's not allowed to get user information without access token.
-fb.Api("huan.du", GET, nil)
+fb.Api("huan.du", http.MethodGet, nil)
 
 // it's possible to specify version per session.
 session := &fb.Session{}

--- a/api.go
+++ b/api.go
@@ -126,7 +126,7 @@ func BatchApi(accessToken string, params ...Params) ([]Result, error) {
 //     // equivalent to following curl command (borrowed from facebook docs)
 //     //     curl \
 //     //         -F 'access_token=…' \
-//     //         -F 'batch=[{"method": http.MethodPost,"relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":http.MethodPost,"relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
+//     //         -F 'batch=[{"method": "POST","relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":"POST","relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
 //     //         -F 'file1=@cat.gif' \
 //     //         -F 'file2=@dog.jpg' \
 //     //         https://graph.facebook.com
@@ -135,12 +135,12 @@ func BatchApi(accessToken string, params ...Params) ([]Result, error) {
 //         "file1": File("cat.gif"),
 //         "file2": File("dog.jpg"),
 //     }, Params{
-//         "method": http.MethodPost,
+//         "method": "POST",
 //         "relative_url": "me/photos",
 //         "body": "message=My cat photo",
 //         "attached_files": "file1",
 //     }, Params{
-//         "method": http.MethodPost,
+//         "method": "POST",
 //         "relative_url": "me/photos",
 //         "body": "message=My dog photo",
 //         "attached_files": "file2",

--- a/api.go
+++ b/api.go
@@ -20,14 +20,6 @@ import (
 	"net/http"
 )
 
-// Facebook graph api methods.
-const (
-	GET    Method = "GET"
-	POST   Method = "POST"
-	DELETE Method = "DELETE"
-	PUT    Method = "PUT"
-)
-
 var (
 	// Version is the default facebook api version.
 	// It can be any valid version string (e.g. "v2.3") or empty.
@@ -45,7 +37,9 @@ var (
 
 var (
 	// default facebook session.
-	defaultSession = &Session{}
+	defaultSession = &Session{
+		HttpClient: http.DefaultClient,
+	}
 )
 
 // DebugMode is the debug mode of Graph API.
@@ -53,7 +47,7 @@ var (
 type DebugMode string
 
 // Method is HTTP method for an API call.
-// Can be GET, POST or DELETE.
+// Can be GET, POST, PUT or DELETE.
 type Method string
 
 // Api makes a facebook graph api call with default session.
@@ -82,22 +76,22 @@ func Api(path string, method Method, params Params) (Result, error) {
 
 // Get is a short hand of Api(path, GET, params).
 func Get(path string, params Params) (Result, error) {
-	return Api(path, GET, params)
+	return Api(path, http.MethodGet, params)
 }
 
 // Post is a short hand of Api(path, POST, params).
 func Post(path string, params Params) (Result, error) {
-	return Api(path, POST, params)
+	return Api(path, http.MethodPost, params)
 }
 
 // Delete is a short hand of Api(path, DELETE, params).
 func Delete(path string, params Params) (Result, error) {
-	return Api(path, DELETE, params)
+	return Api(path, http.MethodDelete, params)
 }
 
 // Put is a short hand of Api(path, PUT, params).
 func Put(path string, params Params) (Result, error) {
-	return Api(path, PUT, params)
+	return Api(path, http.MethodPut, params)
 }
 
 // BatchApi makes a batch facebook graph api call with default session.
@@ -132,7 +126,7 @@ func BatchApi(accessToken string, params ...Params) ([]Result, error) {
 //     // equivalent to following curl command (borrowed from facebook docs)
 //     //     curl \
 //     //         -F 'access_token=…' \
-//     //         -F 'batch=[{"method":"POST","relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":"POST","relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
+//     //         -F 'batch=[{"method": http.MethodPost,"relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":http.MethodPost,"relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
 //     //         -F 'file1=@cat.gif' \
 //     //         -F 'file2=@dog.jpg' \
 //     //         https://graph.facebook.com
@@ -141,12 +135,12 @@ func BatchApi(accessToken string, params ...Params) ([]Result, error) {
 //         "file1": File("cat.gif"),
 //         "file2": File("dog.jpg"),
 //     }, Params{
-//         "method": "POST",
+//         "method": http.MethodPost,
 //         "relative_url": "me/photos",
 //         "body": "message=My cat photo",
 //         "attached_files": "file1",
 //     }, Params{
-//         "method": "POST",
+//         "method": http.MethodPost,
 //         "relative_url": "me/photos",
 //         "body": "message=My dog photo",
 //         "attached_files": "file2",
@@ -166,17 +160,17 @@ func Request(request *http.Request) (Result, error) {
 	return defaultSession.Request(request)
 }
 
-// DefaultHttpClient returns the http client for default session.
-func DefaultHttpClient() HttpClient {
-	return defaultSession.HttpClient
+// SetDefaultHttpClient returns the http client for a default session.
+func SetDefaultHttpClient() {
+	defaultSession.HttpClient = http.DefaultClient
 }
 
 // SetHttpClient updates the http client of default session.
-func SetHttpClient(client HttpClient) {
+func SetHttpClient(client *http.Client) {
 	defaultSession.HttpClient = client
 }
 
 // HttpClient gets the http client of default session.
-func HttpClient() HttpClient {
+func HttpClient() *http.Client {
 	return defaultSession.HttpClient
 }

--- a/api.go
+++ b/api.go
@@ -175,3 +175,8 @@ func DefaultHttpClient() HttpClient {
 func SetHttpClient(client HttpClient) {
 	defaultSession.HttpClient = client
 }
+
+// HttpClient gets the http client of default session.
+func HttpClient() HttpClient {
+	return defaultSession.HttpClient
+}

--- a/api_test.go
+++ b/api_test.go
@@ -8,6 +8,7 @@
 package facebook
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -19,7 +20,7 @@ func TestApiGetUserInfoV2(t *testing.T) {
 
 	// It's not allowed to get user info by name. So I get "me" with access token instead.
 	if FB_TEST_VALID_ACCESS_TOKEN != "" {
-		me, err := Api("me", GET, Params{
+		me, err := Api("me", http.MethodGet, Params{
 			"access_token": FB_TEST_VALID_ACCESS_TOKEN,
 		})
 
@@ -75,11 +76,11 @@ func TestBatchApiGetInfo(t *testing.T) {
 
 	test := func(t *testing.T) {
 		params1 := Params{
-			"method":       GET,
+			"method":       http.MethodGet,
 			"relative_url": "me",
 		}
 		params2 := Params{
-			"method":       GET,
+			"method":       http.MethodGet,
 			"relative_url": uint64(100002828925788), // id of my another facebook account
 		}
 
@@ -117,7 +118,7 @@ func TestBatchApiGetInfo(t *testing.T) {
 
 	// when providing an invalid access token, BatchApi should return a facebook error.
 	_, err := BatchApi("an_invalid_access_token", Params{
-		"method":       GET,
+		"method":       http.MethodGet,
 		"relative_url": "me",
 	})
 

--- a/session.go
+++ b/session.go
@@ -84,22 +84,22 @@ func (session *Session) Api(path string, method Method, params Params) (Result, 
 
 // Get is a short hand of Api(path, GET, params).
 func (session *Session) Get(path string, params Params) (Result, error) {
-	return session.Api(path, GET, params)
+	return session.Api(path, http.MethodGet, params)
 }
 
 // Post is a short hand of Api(path, POST, params).
 func (session *Session) Post(path string, params Params) (Result, error) {
-	return session.Api(path, POST, params)
+	return session.Api(path, http.MethodPost, params)
 }
 
 // Delete is a short hand of Api(path, DELETE, params).
 func (session *Session) Delete(path string, params Params) (Result, error) {
-	return session.Api(path, DELETE, params)
+	return session.Api(path, http.MethodDelete, params)
 }
 
 // Put is a short hand of Api(path, PUT, params).
 func (session *Session) Put(path string, params Params) (Result, error) {
-	return session.Api(path, PUT, params)
+	return session.Api(path, http.MethodPut, params)
 }
 
 // BatchApi makes a batch call. Each params represent a single facebook graph api call.
@@ -169,7 +169,7 @@ func (session *Session) User() (id string, err error) {
 	}
 
 	var result Result
-	result, err = session.Api("/me", GET, Params{"fields": "id"})
+	result, err = session.Api("/me", http.MethodGet, Params{"fields": "id"})
 
 	if err != nil {
 		return
@@ -193,7 +193,7 @@ func (session *Session) Validate() (err error) {
 	}
 
 	var result Result
-	result, err = session.Api("/me", GET, Params{"fields": "id"})
+	result, err = session.Api("/me", http.MethodGet, Params{"fields": "id"})
 
 	if err != nil {
 		return
@@ -228,7 +228,7 @@ func (session *Session) Inspect() (result Result, err error) {
 		return
 	}
 
-	result, err = session.Api("/debug_token", GET, Params{
+	result, err = session.Api("/debug_token", http.MethodGet, Params{
 		"input_token":  session.accessToken,
 		"access_token": appAccessToken,
 	})
@@ -417,8 +417,7 @@ func (session *Session) sendPostRequest(uri string, params Params, res interface
 	}
 
 	var request *http.Request
-
-	request, err = http.NewRequest("POST", uri, buf)
+	request, err = http.NewRequest(http.MethodPost, uri, buf)
 
 	if err != nil {
 		return nil, err
@@ -446,7 +445,7 @@ func (session *Session) sendOauthRequest(uri string, params Params) (Result, err
 
 	var request *http.Request
 
-	request, err = http.NewRequest("POST", urlStr, buf)
+	request, err = http.NewRequest(http.MethodPost, urlStr, buf)
 
 	if err != nil {
 		return nil, err
@@ -516,7 +515,7 @@ func (session *Session) sendRequest(request *http.Request) (response *http.Respo
 }
 
 func (session *Session) isVideoPost(path string, method Method) bool {
-	return method == POST && regexpIsVideoPost.MatchString(path)
+	return method == http.MethodPost && regexpIsVideoPost.MatchString(path)
 }
 
 func (session *Session) getURL(name, path string, params Params) string {

--- a/session_test.go
+++ b/session_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"net/http"
 	"testing"
 )
 
@@ -31,7 +32,7 @@ func TestSession(t *testing.T) {
 
 		t.Logf("current user id is %v", id)
 
-		result, e := session.Api("/me", GET, Params{
+		result, e := session.Api("/me", http.MethodGet, Params{
 			"fields": "id,email,website",
 		})
 
@@ -84,7 +85,7 @@ func TestSession(t *testing.T) {
 		app.EnableAppsecretProof = true
 		session := app.Session(FB_TEST_VALID_ACCESS_TOKEN)
 
-		_, e := session.Api("/me", GET, Params{
+		_, e := session.Api("/me", http.MethodGet, Params{
 			"fields": "id",
 		})
 
@@ -105,7 +106,7 @@ func TestUploadingBinary(t *testing.T) {
 	session := &Session{}
 	session.SetAccessToken(FB_TEST_VALID_ACCESS_TOKEN)
 
-	result, e := session.Api("/me/photos", POST, Params{
+	result, e := session.Api("/me/photos", http.MethodPost, Params{
 		"message": "Test photo from https://github.com/huandu/facebook",
 		"source":  Data("my_profile.jpg", reader),
 	})
@@ -142,7 +143,7 @@ func TestUploadBinaryWithBatch(t *testing.T) {
 	//
 	// curl
 	//     -F 'access_token=…' \
-	//     -F 'batch=[{"method":"POST","relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":"POST","relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
+	//     -F 'batch=[{"method": http.MethodPost,"relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":http.MethodPost,"relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
 	//     -F 'file1=@cat.gif' \
 	//     -F 'file2=@dog.jpg' \
 	//         https://graph.facebook.com
@@ -150,12 +151,12 @@ func TestUploadBinaryWithBatch(t *testing.T) {
 		"file1": Data("cat.jpg", reader1),
 		"file2": Data("dog.jpg", reader2),
 	}, Params{
-		"method":         POST,
+		"method":         http.MethodPost,
 		"relative_url":   "me/photos",
 		"body":           "message=My cat photo",
 		"attached_files": "file1",
 	}, Params{
-		"method":         POST,
+		"method":         http.MethodPost,
 		"relative_url":   "me/photos",
 		"body":           "message=My dog photo",
 		"attached_files": "file2",

--- a/session_test.go
+++ b/session_test.go
@@ -143,7 +143,7 @@ func TestUploadBinaryWithBatch(t *testing.T) {
 	//
 	// curl
 	//     -F 'access_token=…' \
-	//     -F 'batch=[{"method": http.MethodPost,"relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":http.MethodPost,"relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
+	//     -F 'batch=[{"method": "POST","relative_url":"me/photos","body":"message=My cat photo","attached_files":"file1"},{"method":"POST","relative_url":"me/photos","body":"message=My dog photo","attached_files":"file2"},]' \
 	//     -F 'file1=@cat.gif' \
 	//     -F 'file2=@dog.jpg' \
 	//         https://graph.facebook.com

--- a/session_test.go
+++ b/session_test.go
@@ -275,6 +275,7 @@ func TestInspectValidToken(t *testing.T) {
 func TestInspectInvalidToken(t *testing.T) {
 	invalidToken := "CAACZA38ZAD8CoBAe2bDC6EdThnni3b56scyshKINjZARoC9ZAuEUTgYUkYnKdimqfA2ZAXcd2wLd7Rr8jLmMXTY9vqAhQGqObZBIUz1WwbqVoCsB3AAvLtwoWNhsxM76mK0eiJSLXHZCdPVpyhmtojvzXA7f69Bm6b5WZBBXia8iOpPZAUHTGp1UQLFMt47c7RqJTrYIl3VfAR0deN82GMFL2"
 	session := testGlobalApp.Session(invalidToken)
+	session.HttpClient = http.DefaultClient
 	result, err := session.Inspect()
 
 	if err == nil {
@@ -332,7 +333,7 @@ func TestSessionCancelationWithContext(t *testing.T) {
 func TestInspectAppAccessToken(t *testing.T) {
 	app := New(FB_TEST_APP_ID, FB_TEST_APP_SECRET)
 	session := app.Session(app.AppAccessToken())
-
+	session.HttpClient = http.DefaultClient
 	_, err := session.Inspect()
 
 	if err != nil {


### PR DESCRIPTION
Hi again!

This makes session's HttpClient atribute work fully as a http.Client and also enables the manipulation of the client after getting it with `HttpClient()`.

