### PR TITLE
feat: use AuthorizationType while setting the token into http header

### DIFF
--- a/session.go
+++ b/session.go
@@ -283,11 +283,13 @@ func (session *Session) SetAccessToken(token string) {
 // UseAuthorizationHeader passes `access_token` in HTTP Authorization header instead of query string. Set bearer as default Authorization header type
 func (session *Session) UseAuthorizationHeader() {
 	session.useAuthorizationHeader = true
+	session.useOAuthAuthorizationHeader = false
 }
 
 // UseOAuthAuthorizationHeader passes `access_token` in HTTP Authorization header instead of query string. Set Oauth as default Authorization header type
 func (session *Session) UseOAuthAuthorizationHeader() {
 	session.useOAuthAuthorizationHeader = true
+	session.useAuthorizationHeader = false
 }
 
 // AppsecretProof checks appsecret proof is enabled or not.

--- a/session.go
+++ b/session.go
@@ -280,13 +280,13 @@ func (session *Session) SetAccessToken(token string) {
 	}
 }
 
-// UseAuthorizationHeader passes `access_token` in HTTP Authorization header instead of query string. Set bearer as default Authorization header type
+// UseAuthorizationHeader passes `access_token` in HTTP Authorization header instead of query string. Sets bearer as Prefix of Authorization header value
 func (session *Session) UseAuthorizationHeader() {
 	session.useAuthorizationHeader = true
 	session.useOAuthAuthorizationHeader = false
 }
 
-// UseOAuthAuthorizationHeader passes `access_token` in HTTP Authorization header instead of query string. Set Oauth as default Authorization header type
+// UseOAuthAuthorizationHeader passes `access_token` in HTTP Authorization header instead of query string. Set Oauth as Prefix of Authorization header value
 func (session *Session) UseOAuthAuthorizationHeader() {
 	session.useOAuthAuthorizationHeader = true
 	session.useAuthorizationHeader = false


### PR DESCRIPTION
In some cases, we need to use OAuth rather than Bearer token in http headers. This PR addresses this issue.

Example OAuth case [here](https://developers.facebook.com/docs/graph-api/guides/upload/) while uploading a media using upload session.