### PR TITLE
Explicit Instagram session support to use different graph url

### DIFF
--- a/session.go
+++ b/session.go
@@ -41,6 +41,7 @@ var (
 		"graph":       "https://graph.facebook.com/",
 		"graph_video": "https://graph-video.facebook.com/",
 		"www":         "https://www.facebook.com/",
+		"instagram":   "https://graph.instagram.com/",
 	}
 
 	// checks whether it's a video post.
@@ -54,6 +55,7 @@ type Session struct {
 	Version           string // facebook versioning.
 	RFC3339Timestamps bool   // set to true to send date_format=Y-m-d\TH:i:sP on every request which will cause RFC3339 style timestamps to be returned
 	BaseURL           string // set to override API base URL - trailing slash is required, e.g. http://127.0.0.1:53453/
+	Instagram         bool   // set the session explicity to Instagram, see https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/migration-guide#step-2--update-your-code
 
 	accessToken string // facebook access token. can be empty.
 	app         *App
@@ -608,6 +610,9 @@ func (session *Session) getURL(name, path string, params Params) string {
 	baseURL := domainMap[name]
 	if session.BaseURL != "" {
 		baseURL = session.BaseURL
+	} else if session.Instagram && name == "graph" {
+		// see https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/migration-guide#step-2--update-your-code
+		baseURL = domainMap["instagram"]
 	}
 	buf.WriteString(baseURL)
 


### PR DESCRIPTION
Thank you for this awesome library, been using it for the past year and it has worked wonders for my use cases.

Recently Meta as launched a new simplified Instagram Login method where some use cases can bypass Facebook Login and Page requirements that greatly simplifies onboarding of new account to apps like my own that rely only on Instagram auth/api access, more info [here](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/migration-guide)

Part of the change is that any API requests should now be done to https://graph.instagram.com/ instead of https://graph.facebook.com/, more info [here](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/migration-guide#step-2--update-your-code).

So that I could remain using your awesome library without major refactoring, I added a Instagram bool field to the Session struct so that when mapping the "graph" base url and it's an Instagram session it returns it instead of the default Facebook one.

I hope this is useful to someone else, and let me know if you have any questions/feedback.


